### PR TITLE
Revert "chore: bust npm cache []"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
       - checkout
 
       # Install node version from .nvmrc
-      - node/install:
-          with-cache: false
+      - node/install
 
       - run: npm ci
       - run: npm run format-check


### PR DESCRIPTION
Reverts contentful/actions-app-deploy#40

Getting this error message in circle ci: 

Error calling workflow: 'build'
Error calling job: 'lint-and-test'
Error calling command: 'node/install'
Unexpected argument(s): with-cache