### PR TITLE
chore: set Backstage system to app-framework in catalog-info []

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -20,5 +20,6 @@ metadata:
     - tier-unknown
 spec:
   type: function
-  lifecycle: production  
+  lifecycle: production
+  system: app-framework
   owner: group:team-extensibility


### PR DESCRIPTION
## Summary

Adds `spec.system: app-framework` to `catalog-info.yaml` so this component is grouped under the correct system in the service catalog.

## Test plan

- [ ] No CI workflows depend on the previous `system` value.
